### PR TITLE
Makefile.PL: improve META

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -60,7 +60,7 @@ WriteMakefile(
                     recommends => {
                         'DBD::AnyData' => 0,
                         'DBD::SQLite' => 0,
-                        'Time::StopWatch' => 0,
+                        'Time::Stopwatch' => 0,
                     },
                 },
                 develop => {
@@ -69,7 +69,7 @@ WriteMakefile(
                         # Contributors must run the whole testsuite
                         'DBD::AnyData' => 0,
                         'DBD::SQLite' => 0,
-                        'Time::StopWatch' => 0,
+                        'Time::Stopwatch' => 0,
                     },
                 },
             },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-#use 5.008;
+use 5.006;
 use ExtUtils::MakeMaker;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
@@ -23,67 +23,63 @@ WriteMakefile(
         'COMPRESS'     => "gzip -9vf",
     },
 
+    ABSTRACT_FROM => 'lib/POE/Component/EasyDBI.pm', # retrieve abstract from module
+    AUTHOR  => 'David Davis <xantus@cpan.org>',
+
+    ## perl 5.8.9
     (
-        $] >= 5.10.1
-        ? ## Add these new keywords supported since 5.10.1
-          (
-            ABSTRACT_FROM => 'lib/POE/Component/EasyDBI.pm', # retrieve abstract from module
-            LICENSE => 'perl_5',
-            AUTHOR  => 'David Davis <xantus@cpan.org>',
-            MIN_PERL_VERSION =>'5.006000',
-            META_MERGE    => {
-                "meta-spec" => { version => 2 },
-                resources   => {
-                    license => ['http://dev.perl.org/licenses/'],
-                    bugtracker => {
-                        web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=POE-Component-EasyDBI',
-                    },
-                    repository => {
-                        type => 'git',
-                        url  => 'https://github.com/gps4net/POE-Component-EasyDBI.git',
-                        web  => 'https://github.com/gps4net/POE-Component-EasyDBI'
-                    }
+        LICENSE => 'perl_5',
+    )x!! ($eumm_version >= 6.31),
+
+    ## perl 5.10.1
+    (
+        MIN_PERL_VERSION =>'5.006000',
+    )x!! ($eumm_version >= 6.48),
+
+    (
+        META_MERGE    => {
+            "meta-spec" => { version => 2 },
+            resources   => {
+                license => ['http://dev.perl.org/licenses/'],
+                bugtracker => {
+                    web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=POE-Component-EasyDBI',
                 },
-                prereqs => {
-                    test => {
-                        # This is redundant with TEST_REQUIRES, but will
-                        # also work with EUMM 6.46 to 6.63
-                        requires => {
-                            'Test::More' => 0,
-                        },
-                        recommends => {
-                            'DBD::AnyData' => 0,
-                            'DBD::SQLite' => 0,
-                            'Time::StopWatch' => 0,
-                        },
+                repository => {
+                    type => 'git',
+                    url  => 'https://github.com/gps4net/POE-Component-EasyDBI.git',
+                    web  => 'https://github.com/gps4net/POE-Component-EasyDBI'
+                }
+            },
+            prereqs => {
+                test => {
+                    # This is redundant with TEST_REQUIRES, but will
+                    # also work with EUMM 6.46 to 6.63
+                    requires => {
+                        'Test::More' => 0,
                     },
-                    develop => {
-                        requires => {
-                            'CPAN::Meta' => '2.143240', # latest
-                            # Contributors must run the whole testsuite
-                            'DBD::AnyData' => 0,
-                            'DBD::SQLite' => 0,
-                            'Time::StopWatch' => 0,
-                        },
+                    recommends => {
+                        'DBD::AnyData' => 0,
+                        'DBD::SQLite' => 0,
+                        'Time::StopWatch' => 0,
+                    },
+                },
+                develop => {
+                    requires => {
+                        'CPAN::Meta' => '2.143240', # latest
+                        # Contributors must run the whole testsuite
+                        'DBD::AnyData' => 0,
+                        'DBD::SQLite' => 0,
+                        'Time::StopWatch' => 0,
                     },
                 },
             },
-          )
-        : $] >= 5.005
-        ? ## Add these new keywords supported since 5.005
-          (
-            ABSTRACT_FROM => 'lib/POE/Component/EasyDBI.pm', # retrieve abstract from module
-            LICENSE => 'perl_5',
-            AUTHOR  => 'David Davis <xantus@cpan.org>'
-          )
-        : ()
-    ),
-    $eumm_version >= 6.64  # perl 5.18
-    ?
-      (
+        },
+    )x!! ($eumm_version >= 6.46),
+
+    ## perl 5.18
+    (
         TEST_REQUIRES => {
-                'Test::More' => 0,
-            },
-      )
-    : (),
+            'Test::More' => 0,
+        },
+    )x!! ($eumm_version >= 6.64),
 );

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,7 +43,30 @@ WriteMakefile(
                         url  => 'https://github.com/gps4net/POE-Component-EasyDBI.git',
                         web  => 'https://github.com/gps4net/POE-Component-EasyDBI'
                     }
-                }
+                },
+                prereqs => {
+                    test => {
+                        # This is redundant with TEST_REQUIRES, but will
+                        # also work with EUMM 6.46 to 6.63
+                        requires => {
+                            'Test::More' => 0,
+                        },
+                        recommends => {
+                            'DBD::AnyData' => 0,
+                            'DBD::SQLite' => 0,
+                            'Time::StopWatch' => 0,
+                        },
+                    },
+                    develop => {
+                        requires => {
+                            'CPAN::Meta' => '2.143240', # latest
+                            # Contributors must run the whole testsuite
+                            'DBD::AnyData' => 0,
+                            'DBD::SQLite' => 0,
+                            'Time::StopWatch' => 0,
+                        },
+                    },
+                },
             },
           )
         : $] >= 5.005

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,8 @@ use ExtUtils::MakeMaker;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 
+my $eumm_version = eval $ExtUtils::MakeMaker::VERSION;
+
 WriteMakefile(
     'NAME'         => 'POE::Component::EasyDBI',
     'VERSION_FROM' => 'lib/POE/Component/EasyDBI.pm', # finds $VERSION
@@ -53,4 +55,12 @@ WriteMakefile(
           )
         : ()
     ),
+    $eumm_version >= 6.64  # perl 5.18
+    ?
+      (
+        TEST_REQUIRES => {
+                'Test::More' => 0,
+            },
+      )
+    : (),
 );


### PR DESCRIPTION
Improve META in Makefile.PL:
- add Test::More as a TEST_REQUIRES
- add full prereqs including modules used optionally inside tests: they are now marked as `test_recommends` and `develop_requires`
- use $EUMM::VERSION in all EUMM features checks
- refactor Makefile.PL for less duplication and better readability
