### PR TITLE
add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: Perl
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  #schedule:
+  #  - cron: '0 3 * * 0'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest] #, macos-latest, windows-latest
+        perl: [ '5.30', '5.36' ]
+        exclude:
+          - runner: windows-latest
+            perl: '5.36'
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( startsWith( matrix.runner, 'windows-' ) && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+        cpanm -v
+
+    - name: Install dependencies
+      run: |
+        cpanm --installdeps --with-develop --cpanfile cpanfile .
+
+
+    - name: Show Errors on Windows
+      if:  ${{ failure() && startsWith( matrix.runner, 'windows-') }}
+      run: |
+         ls -l C:/Users/
+         ls -l C:/Users/RUNNER~1/
+         cat C:/Users/runneradmin/.cpanm/work/*/build.log
+
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-') }}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Show Errors on OSX
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-') }}
+      run: |
+         cat  /Users/runner/.cpanm/work/*/build.log
+
+    - name: Run tests
+      env:
+        AUTHOR_TESTING: 1
+        RELEASE_TESTING: 1
+      run: |
+        prove -l -v
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ blib/
 *.bak
 *~
 .*
+!.github/
 !.gitignore
 /POE-Component-EasyDBI-*


### PR DESCRIPTION
As mentioned in the Perl Weekly as well, I think it can be really valuable to enable Continuous Integration (CI) and improve testing on all the CPAN modules where the author is interested in it. Having CI configured will provide fast feedback to the author(s) and will reduce the chances of releasing a module that only works on the computer of the developer. Reducing the manual work-load for the CPAN Tester. Currently GitHub Actions is the most natural CI system for GitHub-based projects. That's why I am sending this PR.

I've enabled several versions of Perl on Linux only. On OSX and Windows the test have failed. If they are expected to run then later I could help figuring out the problem.

I have written several blog posts and recorded videos on the subject. You can find them here: https://perlmaven.com/os
If you need further help with the CI system, check out my posts https://perlmaven.com/ci and **feel free to ask me**.

If you'd like to support my efforts there are several ways to do so https://szabgab.com/support.html

